### PR TITLE
Define notCoffee region

### DIFF
--- a/syntax/litcoffee.vim
+++ b/syntax/litcoffee.vim
@@ -7,14 +7,17 @@ if exists('b:current_syntax') && b:current_syntax == 'litcoffee'
   finish
 endif
 
-runtime! syntax/markdown.vim
-unlet b:current_syntax
-
-syn clear markdownCode
-
+syn include @markdown syntax/markdown.vim
 syn include @coffee syntax/coffee.vim
 
+" Partition the file into notCoffee and inlineCoffee. Each line will match
+" exactly one of these regions. notCoffee matches with a zero-width
+" look-behind.
+syn region notCoffee start='^\%(    \|\t\)\@<!' end='$' contains=@markdown
 syn region inlineCoffee start='^    \|\t' end='$' contains=@coffee
 
-let b:current_syntax = "litcoffee"
+" We defined notCoffee as a region so we can highlight every element in it
+" that doesn't have it's own explicit rule.
+highlight default link notCoffee Comment
 
+let b:current_syntax = "litcoffee"


### PR DESCRIPTION
By defining a notCoffee region and containing all the markdown syntax in
it, we can now define a default highlight for everything that's not
Coffeescript.

I like to make the markdown Comment-coloured so that there's greater
visual distinction between the two types of content.